### PR TITLE
Restore color accents and improve pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -84,7 +84,7 @@
         <a href="mailto:oli@roseaboveaccountancy.co.uk" aria-label="Email"><i class="fa-solid fa-envelope"></i></a>
       </div>
       <div style="margin-top:0.7em;">
-        &copy; 2025 Rose Above Accountancy. Accountancy for Musicians & Creatives.<br>
+        &copy; 2025 Rose Above. Accountancy for Musicians & Creatives.<br>
         <small>Professional freelance finance, built for artists.</small>
       </div>
       <div class="footer-credit">

--- a/about.html
+++ b/about.html
@@ -77,6 +77,12 @@
           <p>
             With years of experience and advanced ICAEW ACA studies, I’m passionate about making finance approachable for artists and creatives. My services are modern, jargon-free, and tailored to your unique journey—whether you’re an up-and-coming artist, band, or independent label.
           </p>
+          <p>
+            Beyond spreadsheets, I'm a gigging musician myself. I know how unpredictable tours and releases can be, so my advice focuses on flexibility and real-world practicality.
+          </p>
+          <p>
+            When not crunching numbers you'll find me writing songs or tinkering with synths. I love connecting with fellow creatives and always bring patience and curiosity to every project.
+          </p>
           <ul>
             <li><i class="fa-solid fa-music"></i> Specialist advice for creative industries</li>
             <li><i class="fa-solid fa-guitar"></i> Experience from bedroom studios to festival stages</li>
@@ -115,7 +121,7 @@
         <a href="mailto:oli@roseaboveaccountancy.co.uk" aria-label="Email"><i class="fa-solid fa-envelope"></i></a>
       </div>
       <div style="margin-top:0.7em;">
-        &copy; 2025 Rose Above Accountancy. Accountancy for Musicians & Creatives.<br>
+        &copy; 2025 Rose Above. Accountancy for Musicians & Creatives.<br>
         <small>Professional freelance finance, built for artists.</small>
       </div>
       <div class="footer-credit">

--- a/contact.html
+++ b/contact.html
@@ -65,6 +65,9 @@
     <section id="contact">
       <span class="section-subtitle">Let’s Talk</span>
       <h1 class="section-title">Contact</h1>
+      <p style="max-width:600px;margin:0 auto 1.2em;">
+        Whether you have a quick question or need detailed guidance, I'm always happy to chat. Fill in the form or drop me an email and I'll reply within two days.
+      </p>
       <form id="contactForm" action="https://formspree.io/f/mjkrllva" method="POST" autocomplete="off" novalidate onsubmit="setTimeout(() => { this.reset(); document.getElementById('form-success').style.display = 'block'; }, 300);">
         <div class="cards-container">
           <div class="card" style="flex:2;">
@@ -106,7 +109,7 @@
         <a href="mailto:oli@roseaboveaccountancy.co.uk" aria-label="Email"><i class="fa-solid fa-envelope"></i></a>
       </div>
       <div style="margin-top:0.7em;">
-        &copy; 2025 Rose Above Accountancy. Accountancy for Musicians & Creatives.<br>
+        &copy; 2025 Rose Above. Accountancy for Musicians & Creatives.<br>
         <small>Professional freelance finance, built for artists.</small>
       </div>
       <div class="footer-credit">

--- a/css/style.css
+++ b/css/style.css
@@ -14,8 +14,8 @@
   --text-main: #151515;
   --text-muted: #757575;
   --text-heading: #101114;
-  --accent: #16171c;
-  --accent-hover: #168aad;
+  --accent: #bb4ba2;
+  --accent-hover: #3ee7fa;
   --accent-light: #e9e9e9;
   --accent-faded: #e7e7e7;
   --chequer-light: #fff;
@@ -29,7 +29,7 @@
   --font-main: 'Montserrat', Arial, sans-serif;
   --font-heading: 'Space Grotesk', 'Montserrat', Arial, sans-serif;
   --transition: .19s cubic-bezier(.4,0,.2,1);
-  --input-focus: #168aad;
+  --input-focus: #3ee7fa;
 }
 
 /* ===== DARK THEME ===== */
@@ -568,6 +568,14 @@ section {
   transform: translateY(-8px) scale(1.03);
   background: #f7f7f7;
 }
+#contact .card:last-child {
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  background: linear-gradient(130deg, #3ee7fa11 40%, #bb4ba211 100%);
+  border-left: 4px solid #3ee7fa55;
+  min-width: 280px;
+}
 .card h3 {
   font-size: 1.17rem;
   color: #16171c;
@@ -586,6 +594,7 @@ section {
   margin-bottom: 0.42em;
   background: linear-gradient(135deg, #fff 60%, #222 140%);
   border-radius: 50%;
+  aspect-ratio: 1 / 1;
   padding: 0.18em;
   display: inline-block;
   border: 2px solid #fff;
@@ -752,6 +761,7 @@ section {
   color: #fff !important;
   border: none;
   border-radius: 50%;
+  aspect-ratio: 1 / 1;
   width: 44px;
   height: 44px;
   font-size: 1.55em;
@@ -1043,6 +1053,49 @@ footer .ska-accent {
   opacity: 0.16;
 }
 .site-footer {background:#181818;color:#fff;text-align:center;padding:2.8rem 1.2rem 1.5rem;margin-top:3.2rem;border-radius:0 0 var(--radius) var(--radius);box-shadow:0 -2px 28px #0002;}
+.footer-main-logo {
+  height: 120px;
+  width: auto;
+  max-width: 400px;
+  display: block;
+  margin: 0 auto 2em auto;
+  border-radius: 20px;
+  box-shadow: none;
+  background: none;
+}
+#backToTop {
+  display: none;
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  z-index: 900;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 50%;
+  aspect-ratio: 1 / 1;
+  width: 48px;
+  height: 48px;
+  box-shadow: 0 2px 8px #0002;
+  cursor: pointer;
+  font-size: 1.8rem;
+  transition: opacity 0.2s, background 0.2s, color 0.2s;
+  opacity: 0.7;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+#backToTop:hover {
+  opacity: 1;
+  background: var(--accent-hover);
+  color: #fff;
+}
+@media (max-width: 600px) {
+  .footer-main-logo {
+    height: 78px;
+    max-width: 220px;
+  }
+}
 
 /* ===== RESPONSIVE ===== */
 @media (max-width: 1280px) {

--- a/index.html
+++ b/index.html
@@ -599,7 +599,7 @@
       <!-- LOGO WATERMARK -->
       <picture>
         <source srcset="images/Rose Above Logo - White.png" media="(prefers-color-scheme: dark)">
-        <img src="images/Rose Above Logo - Black.png" alt="Rose Above Logo Watermark" style="position:absolute;right:2vw;top:2vw;opacity:0.06;height:100px;width:auto;pointer-events:none;z-index:1;" class="logo-lightmode">
+        <img src="images/Rose Above Logo - Black.png" alt="Rose Above Logo Watermark" style="position:absolute;right:2vw;top:2vw;opacity:0.06;height:65px;width:auto;pointer-events:none;z-index:1;" class="logo-lightmode">
       </picture>
       <div class="gallery-slideshow">
         <button class="gallery-btn prev" aria-label="Previous image"><i class="fa-solid fa-arrow-left"></i></button>
@@ -768,7 +768,7 @@
         <a href="mailto:oli@roseaboveaccountancy.co.uk" aria-label="Email"><i class="fa-solid fa-envelope"></i></a>
       </div>
       <div style="margin-top:0.7em;">
-        &copy; 2025 Rose Above Accountancy. Accountancy for Musicians & Creatives.<br>
+        &copy; 2025 Rose Above. Accountancy for Musicians & Creatives.<br>
         <small>You create. We calculate.</small>
       </div>
       <div class="footer-credit">

--- a/portfolio.html
+++ b/portfolio.html
@@ -68,6 +68,12 @@
       <p>
         I've had the privilege to work with a wide range of creative clients, from solo musicians and bands to indie labels and creative startups. Here are just a few highlights:
       </p>
+      <p>
+        Each project has sharpened my understanding of the music business and the financial challenges creatives face. Whether it's sorting out touring budgets or setting up robust royalty systems, I love helping clients see the bigger picture.
+      </p>
+      <p>
+        Collaboration and transparency are at the heart of my process. I stay in regular contact with clients, delivering clear reports and straightforward advice so you always feel confident about your next move.
+      </p>
       <div class="cards-container">
         <div class="card">
           <h3><i class="fa-solid fa-guitar"></i> Indie Band Tour Finance</h3>
@@ -110,7 +116,7 @@
         <a href="mailto:oli@roseaboveaccountancy.co.uk" aria-label="Email"><i class="fa-solid fa-envelope"></i></a>
       </div>
       <div style="margin-top:0.7em;">
-        &copy; 2025 Rose Above Accountancy. Accountancy for Musicians & Creatives.<br>
+        &copy; 2025 Rose Above. Accountancy for Musicians & Creatives.<br>
         <small>Professional freelance finance, built for artists.</small>
       </div>
       <div class="footer-credit">

--- a/privacy.html
+++ b/privacy.html
@@ -108,7 +108,7 @@
         <a href="mailto:oli@roseaboveaccountancy.co.uk" aria-label="Email"><i class="fa-solid fa-envelope"></i></a>
       </div>
       <div style="margin-top:0.7em;">
-        &copy; 2025 Rose Above Accountancy. Accountancy for Musicians & Creatives.<br>
+        &copy; 2025 Rose Above. Accountancy for Musicians & Creatives.<br>
         <small>Professional freelance finance, built for artists.</small>
       </div>
       <div class="footer-credit">

--- a/services.html
+++ b/services.html
@@ -67,7 +67,7 @@
       <h2 class="section-title">Our Services</h2>
       <div class="cards-container">
         <div class="card">
-          <span class="service-icon"><i class="fa-solid fa-file-invoice"></i></span>
+          <span class="service-icon"><i class="fa-solid fa-book-open"></i></span>
           <h3>Bookkeeping</h3>
           <p>Detailed financial tracking ensuring accurate record-keeping for artists and labels.</p>
         </div>
@@ -86,6 +86,7 @@
         <h3>Why Choose Me?</h3>
         <p>
           I combine industry expertise with a passion for music. My dedicated approach creates financial harmony in your creative endeavors.<br>
+          By keeping up with the latest industry changes I can help you navigate new opportunities, from digital royalties to grant funding. Everything is tailored so you stay inspired and in control.
           <a href="contact.html" class="btn" style="margin-top:1em;">Get in Touch</a>
         </p>
       </div>
@@ -110,7 +111,7 @@
         <a href="mailto:oli@roseaboveaccountancy.co.uk" aria-label="Email"><i class="fa-solid fa-envelope"></i></a>
       </div>
       <div style="margin-top:0.7em;">
-        &copy; 2025 Rose Above Accountancy. Accountancy for Musicians & Creatives.<br>
+        &copy; 2025 Rose Above. Accountancy for Musicians & Creatives.<br>
         <small>Professional freelance finance, built for artists.</small>
       </div>
       <div class="footer-credit">

--- a/terms.html
+++ b/terms.html
@@ -112,7 +112,7 @@
         <a href="mailto:oli@roseaboveaccountancy.co.uk" aria-label="Email"><i class="fa-solid fa-envelope"></i></a>
       </div>
       <div style="margin-top:0.7em;">
-        &copy; 2025 Rose Above Accountancy. Accountancy for Musicians & Creatives.<br>
+        &copy; 2025 Rose Above. Accountancy for Musicians & Creatives.<br>
         <small>Professional freelance finance, built for artists.</small>
       </div>
       <div class="footer-credit">

--- a/thankyou.html
+++ b/thankyou.html
@@ -107,7 +107,7 @@
         <a href="mailto:oli@roseaboveaccountancy.co.uk" aria-label="Email"><i class="fa-solid fa-envelope"></i></a>
       </div>
       <div style="margin-top:0.7em;">
-        &copy; 2025 Rose Above Accountancy. Accountancy for Musicians & Creatives.<br>
+        &copy; 2025 Rose Above. Accountancy for Musicians & Creatives.<br>
         <small>Professional freelance finance, built for artists.</small>
       </div>
       <div class="footer-credit">


### PR DESCRIPTION
## Summary
- keep service and arrow icons circular on mobile
- reduce gallery watermark size
- switch bookkeeping icon to a book
- update footer copyright text
- expand copy on About, Services, Portfolio and Contact pages
- add global back-to-top button styles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68659a1e2b34832eb76fa375d8cf2b4c